### PR TITLE
imx6qdl-wandboard.dtsi: Bump HDMI's default bit depth to 32 bits

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-wandboard.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-wandboard.dtsi
@@ -120,7 +120,7 @@
 		disp_dev = "hdmi";
 		interface_pix_fmt = "RGB24";
 		mode_str ="1920x1080M@60";
-		default_bpp = <24>;
+		default_bpp = <32>;
 		int_clk = <0>;
 		late_init = <0>;
 		status = "disabled";


### PR DESCRIPTION
Weston needs the default HDMI bit depth set at 32 bits in order to start.
