### PR TITLE
imx6qdl-wandboard.dtsi: fix uart3 pinctrl settings

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-wandboard.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-wandboard.dtsi
@@ -820,21 +820,13 @@ reference manual.
 	uart3 {
 		pinctrl_uart3_1: uart3grp-1 {
 			fsl,pins = <
-				MX6QDL_PAD_SD4_CLK__UART3_RX_DATA 0x1b0b1
-				MX6QDL_PAD_SD4_CMD__UART3_TX_DATA 0x1b0b1
-				MX6QDL_PAD_EIM_D30__UART3_CTS_B   0x1b0b1
+				MX6QDL_PAD_EIM_D24__UART3_TX_DATA 0x1b0b1
+				MX6QDL_PAD_EIM_D25__UART3_RX_DATA 0x1b0b1
+				MX6QDL_PAD_EIM_D23__UART3_CTS_B   0x1b0b1
 				MX6QDL_PAD_EIM_EB3__UART3_RTS_B   0x1b0b1
 			>;
 		};
 
-		pinctrl_uart3dte_1: uart3dtegrp-1 {
-			fsl,pins = <
-				MX6QDL_PAD_SD4_CLK__UART3_TX_DATA 0x1b0b1
-				MX6QDL_PAD_SD4_CMD__UART3_RX_DATA 0x1b0b1
-				MX6QDL_PAD_EIM_D30__UART3_RTS_B   0x1b0b1
-				MX6QDL_PAD_EIM_EB3__UART3_CTS_B   0x1b0b1
-			>;
-		};
 	};
 
 	uart4 {


### PR DESCRIPTION
The uart3 pad settings didn't get brought forward correctly from the 3.10.53 branch, which breaks Bluetooth.  This patch corrects the pad settings (and eliminates the unused DTE flavor), which gets the Bluetooth adapter working on my rev C1 quad.
